### PR TITLE
Can set extra fields requested via Meteor.settings

### DIFF
--- a/linkedin_server.js
+++ b/linkedin_server.js
@@ -22,7 +22,7 @@ OAuth.registerService('linkedin', 2, null, function(query) {
 
   // list of extra fields
   // http://developer.linkedin.com/documents/profile-fields
-  var extraFields = 'email-address,location:(name),num-connections,picture-url;secure=true,public-profile-url,skills,languages,three-current-positions,recommendations-received';
+  var extraFields = (Meteor.settings && Meteor.settings.linkedin && Meteor.settings.linkedin.extraFields) || 'email-address,location:(name),num-connections,picture-url;secure=true,public-profile-url,skills,languages,three-current-positions,recommendations-received';
 
   // remove the whitespaces which could break the request
   extraFields = extraFields.replace(/\s+/g, '');


### PR DESCRIPTION
The current value of `extraFields` remains as a default.

I want this change so that I can set `Meteor.settings.linkedin.extraFields` to

```
"email-address,location:(name),picture-url;secure=true,public-profile-url,positions"
```

because the "positions" field only requires request of the basic profile, whereas "three-current-positions" (which is hard-coded as an extra field in this package) requires request of the full profile.

I currently use `Meteor.settings.linkedin` to set  "clientId" and "secret" during app initialization (after `meteor add service-configuration`),

```
ServiceConfiguration.configurations.remove({
  service: "linkedin"
});
ServiceConfiguration.configurations.insert({
  service: "linkedin",
  clientId: Meteor.settings.linkedin.clientId,
  secret: Meteor.settings.linkedin.secret
});
```

so having `extraFields` accessible as a property of `Meteor.settings.linkedin` would be convenient.
